### PR TITLE
run.cfm style update and moved source, mapping and export to variables

### DIFF
--- a/run.cfm
+++ b/run.cfm
@@ -13,8 +13,8 @@
 		<h1 id="title">ColdDoc Generator</h1>
 		<div id="main">
 		<cfscript>
-			// Config
-			source = "./ColdDoc"; // The source code folder we are generating documentation for
+			// Config - The default will generate documentation for ColdDoc
+			source = "/ColdDoc"; // The source code folder we are generating documentation for
 			mapping = "colddoc"; // The folder name used for mapping
 			docPath = "./Docs/ColdDoc"; // The location of where we are putting the documentation
 			


### PR DESCRIPTION
Source, mapping and export paths are now variables and clearly commented. Also added basic formatting for the run.cfm page. Added additional information output such as the relative / absolute path of the documentation. Also changed link to documentation to variable incase export directory is changed.
