### PR TITLE
BUGFIX: Missing pound sign in ExpandPath(), added better wording for custom strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ box install docbox
 If you want to use DocBox for document generation in your CFML application, then just drop it into any location and create a `/docbox` mapping to it.  You will then instantiate the `DocBox` generator class with a `strategy` and `properties` for the strategy.
 
 ```js
-// signature
+// use custom strategy found at class.path
 docbox = new DocBox( strategy="class.path", properties={} );
 
 // create with default strategy
@@ -55,7 +55,7 @@ To generate the documentation you will then execute the `generate()` method on t
 docbox.generate( source="/my/path", mapping="coldbox" );
 
 docbox.generate(
-    source  = "#expandPath( '/docbox' )",
+    source  = "#expandPath( '/docbox' )#",
     mapping = "coldbox",
     excludes = "tests"
 );


### PR DESCRIPTION
This line had a syntax error:
```js
source  = "#expandPath( '/docbox' )"
```

and some of the strategy documentation is unclear - what is a strategy? I put some more strategy info in the wiki, but left the README with just a more clear "this is how to specify a custom strategy" statement.

In my opinion the docs need some attention from folks (like me) who are new to the project.

```js
// signature
 docbox = new DocBox( strategy="class.path", properties={} );
```

^^ What is "signature", for example? I changed this in hopes that a more detailed comment makes things a little easier for the next newbie.

Hope this helps!