### PR TITLE
Use relative file path with excludes regex

### DIFF
--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -103,7 +103,9 @@ component accessors="true"{
 			// iterate over files found
 			for( var thisFile in aFiles ){
 				// Excludes?
-				if( len( arguments.excludes ) && rEFindNoCase( arguments.excludes, thisFile ) ){
+				// Use relative file path so placement on disk doesn't affect the regex check
+				var relativeFilePath = replace( thisFile, thisInput.dir, "" );
+				if( len( arguments.excludes ) && rEFindNoCase( arguments.excludes, relativeFilePath ) ){
 					continue;
 				}
 				// get current path


### PR DESCRIPTION
A relative file path won't be affected by things like placement on disk.
For instance, an excludes regex of `modules` will exclude everything
if the code is placed inside a `coldbox-modules` folder.