### PR TITLE
[RFC]: Add JSON output strategy and *tests* for all docbox output formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,25 @@
-#ignore these files
-!.gitignore
+## OS and IDEs
+testbox
+.DS_Store
+.settings
 settings.xml
+.vscode
+.project
+WEB-INF
+
+# Dependencies
+coldbox/*
+testbox
+modules/*
+
+# Engines
+.engine/**
+.env
+
+# NPM Dependencies
+**/node_modules/*
+
+## Builds (DocBox-specific)
 *.iml
 tests/output/*
 tests/node_modules
@@ -8,5 +27,3 @@ build/build.number
 artifacts/*
 build-docbox/*
 tests/DocBox-APIDocs
-.vscode
-testbox

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ modules/*
 ## Builds (DocBox-specific)
 *.iml
 tests/output/*
+tests/resources/tmp
 tests/node_modules
 build/build.number
 artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ artifacts/*
 build-docbox/*
 tests/DocBox-APIDocs
 .vscode
+testbox

--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -65,6 +65,7 @@ component accessors="true"{
 				case "JSONAPISTRATEGY":
 					arguments.strategy = "docbox.strategy.json.JSONAPIStrategy";
 				break;
+				case "UML":
 				case "XMI":
 				case "XMISTRATEGY":
 					arguments.strategy = "docbox.strategy.uml2tools.XMIStrategy";

--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -13,6 +13,10 @@ component accessors="true"{
 
 	/**
 	* Constructor
+	* 
+	* @strategy The documentation output strategy to utilize.
+	* @properties Struct of data properties required for the specific output strategy
+	* @return The DocBox instance
 	*/
 	DocBox function init(
 		any strategy ="",
@@ -30,7 +34,9 @@ component accessors="true"{
 
 	/**
 	 * Backwards-compatible setter to add a strategy to the docbox configuration.
+	 * 
 	 * @see addStrategy
+	 * @return The DocBox instance
 	 */
 	DocBox function setStrategy(){
 		return addStrategy( argumentCollection = arguments );
@@ -42,6 +48,7 @@ component accessors="true"{
 	 * @strategy The optional strategy to generate the documentation with. This can be a class path or an instance of the  strategy. If none is passed then
 	 * we create the default strategy of 'docbox.strategy.api.HTMLAPIStrategy'
 	 * @properties The struct of properties to instantiate the strategy with.
+	 * @return The DocBox instance
 	 */
 	DocBox function addStrategy( any strategy ="docbox.strategy.api.HTMLAPIStrategy", struct properties = {} ){
 		var newStrategy;
@@ -88,10 +95,10 @@ component accessors="true"{
 		}
 
 		// build metadata collection
-		var qMetaData = buildMetaDataCollection( thisSource, arguments.excludes );
+		var metadata = buildMetaDataCollection( thisSource, arguments.excludes );
 
 		getStrategies().each( function( strategy ) {
-			strategy.run( qMetaData );
+			strategy.run( metadata );
 		});
 
 		return this;
@@ -101,6 +108,7 @@ component accessors="true"{
 
 	/**
 	* Clean input path
+	* 
 	* @path The incoming path to clean
 	* @inputDir The input dir to clean off
 	*/
@@ -113,11 +121,12 @@ component accessors="true"{
 
 	/**
 	* Builds the searchable meta data collection
+	* 
 	* @inputSource an array of structs containing inputDir and mapping
 	* @excludes	A regex that will be applied to the input source to exclude from the docs
 	*/
 	query function buildMetaDataCollection( required array inputSource, string excludes="" ){
-		var qMetaData = QueryNew( "package,name,extends,metadata,type,implements,fullextends,currentMapping" );
+		var metadata = QueryNew( "package,name,extends,metadata,type,implements,fullextends,currentMapping" );
 
 		// iterate over input sources
 		for( var thisInput in arguments.inputSource ){
@@ -161,33 +170,33 @@ component accessors="true"{
 	                }
 
 	                // Add row
-					QueryAddRow( qMetaData );
+					QueryAddRow( metadata );
 					// Add contents
-	                QuerySetCell( qMetaData, "package",  		packagePath );
-	                QuerySetCell( qMetaData, "name", 	 		cfcName );
-	                QuerySetCell( qMetaData, "metadata", 		meta );
-					QuerySetCell( qMetaData, "type", 	 		meta.type );
-					QuerySetCell( qMetaData, "currentMapping", 	thisInput.mapping );
+	                QuerySetCell( metadata, "package",  		packagePath );
+	                QuerySetCell( metadata, "name", 	 		cfcName );
+	                QuerySetCell( metadata, "metadata", 		meta );
+					QuerySetCell( metadata, "type", 	 		meta.type );
+					QuerySetCell( metadata, "currentMapping", 	thisInput.mapping );
 
 					// Get implements
 					var implements = getImplements( meta );
 					implements = listQualify( arrayToList( implements ), ':' );
-					QuerySetCell( qMetaData, "implements", implements );
+					QuerySetCell( metadata, "implements", implements );
 
 					// Get inheritance
 					var fullextends = getInheritance( meta );
 					fullextends = listQualify( arrayToList( fullextends ), ':' );
-					QuerySetCell( qMetaData, "fullextends", fullextends );
+					QuerySetCell( metadata, "fullextends", fullextends );
 
 	                //so we cane easily query direct desendents
 	                if( StructKeyExists( meta, "extends" ) ){
 						if( meta.type eq "interface" ){
-							QuerySetCell( qMetaData, "extends", meta.extends[ structKeyList( meta.extends ) ].name );
+							QuerySetCell( metadata, "extends", meta.extends[ structKeyList( meta.extends ) ].name );
 						} else						{
-		                    QuerySetCell( qMetaData, "extends", meta.extends.name );
+		                    QuerySetCell( metadata, "extends", meta.extends.name );
 						}
 	                } else {
-	                    QuerySetCell( qMetaData, "extends", "-" );
+	                    QuerySetCell( metadata, "extends", "-" );
 	                }
 
 				}
@@ -208,12 +217,14 @@ component accessors="true"{
 			} // end qFiles iteration
 		} // end input source iteration
 
-		return qMetadata;
+		return metadata;
 	}
 
 	/**
 	* Gets an array of the classes that this metadata implements, in order of extension
+	* 
 	* @metadata The metadata to look at
+	* @return array of component interfaces implemented by some component in this package
 	*/
 	private array function getImplements( required struct metadata ){
 		var interfaces = {};
@@ -241,7 +252,9 @@ component accessors="true"{
 
 	/**
 	* Gets an array of the classes that this metadata extends, in order of extension
+	* 
 	* @metadata The metadata to look at
+	* @return array of classes inherited by some component in this package
 	*/
 	private array function getInheritance( required struct metadata ){
 		//ignore top level

--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -56,6 +56,21 @@ component accessors="true"{
 		if( isObject( arguments.strategy ) ){
 			newStrategy = arguments.strategy;
 		} else {
+			switch( uCase( arguments.strategy ) ){
+				case "HTML":
+				case "HTMLAPISTRATEGY":
+					arguments.strategy = "docbox.strategy.api.HTMLAPIStrategy";
+				break;
+				case "JSON":
+				case "JSONAPISTRATEGY":
+					arguments.strategy = "docbox.strategy.json.JSONAPIStrategy";
+				break;
+				case "XMI":
+				case "XMISTRATEGY":
+					arguments.strategy = "docbox.strategy.uml2tools.XMIStrategy";
+				default:
+				break;
+			}
 			newStrategy = new "#arguments.strategy#"( argumentCollection=arguments.properties );
 		}
 		setStrategies( getStrategies().append( newStrategy ) );

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Once the generation finalizes, you will see your beautiful docs!
   * `outputFile` : The output file
 
 ### CommandBox Command
-There is a related project you can install which wraps up the DocBox libraray in a Custom CLI command so you can generate API docs from the command line.
+There is a related project you can install which wraps up the DocBox library in a Custom CLI command so you can generate API docs from the command line.
 ```bash
 box install commandbox-docbox
 ```
@@ -103,4 +103,4 @@ I THANK GOD FOR HIS WISDOM FOR THIS PROJECT
 
 ## Have Questions?
 
-Come find us on the [CFML Slack]() (#box-products channel) and ask us there.  We'd be happy to help!
+Come find us on the [CFML Slack](http://cfml-slack.herokuapp.com/) (#box-products channel) and ask us there.  We'd be happy to help!

--- a/box.json
+++ b/box.json
@@ -36,6 +36,6 @@
         "run.cfm"
     ],
     "testbox":{
-        "runner":"http://localhost:64492/tests/run.cfm"
+        "runner":"http://localhost:64492/tests/runner.cfm"
     }
 }

--- a/box.json
+++ b/box.json
@@ -1,38 +1,37 @@
 {
-    "name": "DocBox",
-    "version": "@build.version@+@build.number@",
-    "author": "Ortus Solutions, Corp",
-    "location": "http://downloads.ortussolutions.com/ortussolutions/docbox/@build.version@/docbox-@build.version@.zip",
-    "homepage": "https://www.ortussolutions.com",
-    "documentation": "https://github.com/Ortus-Solutions/DocBox/wiki",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Ortus-Solutions/DocBox"
+    "name":"DocBox",
+    "version":"@build.version@+@build.number@",
+    "author":"Ortus Solutions, Corp",
+    "location":"http://downloads.ortussolutions.com/ortussolutions/docbox/@build.version@/docbox-@build.version@.zip",
+    "homepage":"https://www.ortussolutions.com",
+    "documentation":"https://github.com/Ortus-Solutions/DocBox/wiki",
+    "repository":{
+        "type":"git",
+        "url":"https://github.com/Ortus-Solutions/DocBox"
     },
-    "bugs": "https://ortussolutions.atlassian.net/projects/DOCBOX",
-    "slug": "docbox",
-    "shortDescription": "API Documentation generator for ColdFusion (CFML)",
-    "type": "projects",
-    "keywords": "apidocs, coldfusion docs, javadocs, cfc docs",
-    "license": [{
-        "type": "Apache2",
-        "url": "https://www.apache.org/licenses/LICENSE-2.0"
-    }],
-    "contributors": [
+    "bugs":"https://ortussolutions.atlassian.net/projects/DOCBOX",
+    "slug":"docbox",
+    "shortDescription":"API Documentation generator for ColdFusion (CFML)",
+    "type":"projects",
+    "keywords":"apidocs, coldfusion docs, javadocs, cfc docs",
+    "license":[
+        {
+            "type":"Apache2",
+            "url":"https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ],
+    "contributors":[
         "Brad Wood <brad@bradwood.com>"
     ],
-    "dependencies": {
-
-    },
-    "devDependencies": {
-
-    },
-    "installPaths": {
-
-    },
-    "ignore": [
+    "dependencies":{},
+    "devDependencies":{},
+    "installPaths":{},
+    "ignore":[
         "**/.*",
         "tests/**",
         "run.cfm"
-    ]
+    ],
+    "testbox":{
+        "runner":"http://localhost:64492/tests/run.cfm"
+    }
 }

--- a/box.json
+++ b/box.json
@@ -24,8 +24,12 @@
         "Brad Wood <brad@bradwood.com>"
     ],
     "dependencies":{},
-    "devDependencies":{},
-    "installPaths":{},
+    "devDependencies":{
+        "testbox":"^4.1.0+384"
+    },
+    "installPaths":{
+        "testbox":"testbox/"
+    },
     "ignore":[
         "**/.*",
         "tests/**",

--- a/strategy/AbstractTemplateStrategy.cfc
+++ b/strategy/AbstractTemplateStrategy.cfc
@@ -57,7 +57,7 @@ component doc_abstract="true" accessors="true"{
 		var tree = {};
 		for( var thisRow in qPackages ){
 			var node = tree;
-			var aPackage = listToArray( thisRow, "." );
+			var aPackage = listToArray( thisRow["package"], "." );
 
 			for( var thisPath in aPackage ){
 				if( not structKeyExists( node, thisPath ) ){

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -56,15 +56,6 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 			}, [])
 		);
 
-
-		/**
-		 * Generate top-level JSON package index
-		 */
-		serializeToFile(
-			getOutputDir() & "/overview-summary.json",
-			buildPackageSummary( classes )
-		);
-
 		/**
 		 * Generate hierarchical JSON package indices with classes
 		 */
@@ -75,6 +66,14 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 			results[ class.package ].append( class );
 			return results;
 		}, {});
+
+		/**
+		 * Generate top-level JSON package index
+		 */
+		serializeToFile(
+			getOutputDir() & "/overview-summary.json",
+			buildOverviewSummary( classes, packages )
+		);
 
 		/**
 		 * Output a hierarchical folder structure which matches the original package structure -
@@ -102,6 +101,23 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 		});
 
 		return this;
+	}
+
+	/**
+	 * Marshall component names and paths into a package-summary.json file for each package hierarchy level
+	 *
+	 * @classData Component metadata sourced from DocBox
+	 * @packages Array of packages for linking to package summary files
+	 */
+	package struct function buildOverviewSummary( required array classData, required struct packages ){
+		var summary = buildPackageSummary( arguments.classData );
+		summary[ "packages" ] = arguments.packages.map( ( package ) => {
+			return {
+				"name" : package,
+				"path" : "#replace( package , ".", "/", "all" )#/package-summary.json"
+			}
+		});
+		return summary;
 	}
 
 	/**

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -167,16 +167,6 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 		});
 	}
 
-	package struct function reducePackages( classData ){
-		return classData.reduce( function( result, class ) {
-			if ( !classData.keyExists( class.package ) ){
-				result[ class.package ] = [];
-			}
-			arrayAppend( result[ class.package ], class );
-			return result;
-		}, {});
-	}
-
 	/**
 	 * Serialize the given @data into JSON and write to @path.
 	 *

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -151,7 +151,7 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 						"hint" : method.keyExists( "hint" ) ? method.hint : "",
 						"description" : method.keyExists( "description" ) ? method.description : "",
 						"access" : method.access,
-						"position" : method.position
+						"position" : method.keyExists( "position" ) ? method.position : { "start":0,"end":0 }
 					}
 				} );
 			}

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -100,26 +100,28 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 			/**
 			 * Marshall functions to match the designed schema;
 			 */
-			var metaFunctions = row.metadata.functions.map( ( method ) => {
-				return {
-					"returnType" : method.returnType,
-					"returnFormat" : method.returnFormat,
-					"parameters" : method.parameters,
-					"name" : method.name,
-					"hint" : method.keyExists( "hint" ) ? method.hint : "",
-					"description" : method.keyExists( "description" ) ? method.description : "",
-					"access" : method.access,
-					"position" : method.position
-				}
-			} );
+			if ( !isNull( row.metadata.functions ) ){
+				var metaFunctions = row.metadata.functions.map( ( method ) => {
+					return {
+						"returnType" : method.returnType,
+						"returnFormat" : method.returnFormat,
+						"parameters" : method.parameters,
+						"name" : method.name,
+						"hint" : method.keyExists( "hint" ) ? method.hint : "",
+						"description" : method.keyExists( "description" ) ? method.description : "",
+						"access" : method.access,
+						"position" : method.position
+					}
+				} );
+			}
 			return {
 				"name" : row.name,
 				"package" : row.package,
 				"type" : row.type,
-				"extends" : row.extends,
-				"fullextends" : row.fullextends,
-				"hint" : row.metadata.hint,
-				"functions" : metaFunctions
+				"extends" : structKeyExists( row.metadata, "extends" ) ? row.extends : "",
+				"fullextends" : structKeyExists( row.metadata, "fullextends" ) ? row.fullextends : "",
+				"hint" : structKeyExists( row.metadata, "hint" ) ? row.metadata.hint : "",
+				"functions" : structKeyExists( row.metadata, "functions" ) ? metaFunctions : []
 			};
 		});
 	}

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -42,13 +42,6 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 	component function run( required query metadata ){
 		ensureDirectory( getOutputDir() );
 
-		// write the index template
-		var args = {
-			path 		 = getOutputDir() & "/index.json", 
-			template 	 = "#variables.static.TEMPLATE_PATH#/index.cfm", 
-			projectTitle = getProjectTitle()
-		};
-
 		var classes = normalizePackages(
 			arguments.metadata.reduce( ( results, row ) => {
 				results.append( row );
@@ -110,14 +103,16 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 	 * @packages Array of packages for linking to package summary files
 	 */
 	package struct function buildOverviewSummary( required array classData, required struct packages ){
-		var summary = buildPackageSummary( arguments.classData );
-		summary[ "packages" ] = arguments.packages.map( ( package ) => {
-			return {
-				"name" : package,
-				"path" : "#replace( package , ".", "/", "all" )#/package-summary.json"
-			}
-		});
-		return summary;
+		return {
+			"classes" : buildPackageSummary( arguments.classData ).classes,
+			"packages" : arguments.packages.map( ( package ) => {
+				return {
+					"name" : package,
+					"path" : "#replace( package , ".", "/", "all" )#/package-summary.json"
+				}
+			}),
+			"title" : getProjectTitle()
+		};
 	}
 
 	/**

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -85,18 +85,9 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 	}
 
 	package array function normalize( required array classData ){
-		var componentMeta = [ "hint", "extends", "functions", "fullname", "properties", "remoteAddress", "type", "hashCode", "name", "path" ];
-		var functionMeta = [ "name", "hint", "description", "access", "closure", "owner", "position", "returnFormat", "returnType", "modifier", "parameters" ];
 		return arguments.classData.map( function( row ) {
 			/**
-			 * Marshall component metadata into attributes array.
-			 */
-			var metaAttributes = row.metadata.filter( ( key ) => {
-				return !arrayContainsNoCase( componentMeta, key );
-			});
-			/**
 			 * Marshall functions to match the designed schema;
-			 * including generating an "attributes" array of attributes not described elsewhere on the function.
 			 */
 			var metaFunctions = row.metadata.functions.map( ( method ) => {
 				return {
@@ -107,10 +98,7 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 					"hint" : method.keyExists( "hint" ) ? method.hint : "",
 					"description" : method.keyExists( "description" ) ? method.description : "",
 					"access" : method.access,
-					"position" : method.position,
-					"attributes" : method.filter( ( key ) => {
-						return !arrayContainsNoCase( functionMeta, key );
-					})
+					"position" : method.position
 				}
 			} );
 			return {
@@ -120,7 +108,6 @@ component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
 				"extends" : row.extends,
 				"fullextends" : row.fullextends,
 				"hint" : row.metadata.hint,
-				"attributes" : metaAttributes,
 				"functions" : metaFunctions
 			};
 		});

--- a/strategy/json/JSONAPIStrategy.cfc
+++ b/strategy/json/JSONAPIStrategy.cfc
@@ -1,0 +1,152 @@
+/**
+* Default Document Strategy for DocBox
+* <br>
+* <small><em>Copyright 2015 Ortus Solutions, Corp <a href="www.ortussolutions.com">www.ortussolutions.com</a></em></small>
+*/
+component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
+
+	/**
+	* The output directory
+	*/
+	property name="outputDir" type="string";
+
+	/**
+	* The project title to use
+	*/
+	property name="projectTitle" default="Untitled" type="string";
+
+	// Static variables.
+	variables.static.TEMPLATE_PATH	= "/docbox/strategy/json/resources/templates";
+	variables.static.ASSETS_PATH 	= "/docbox/strategy/json/resources/static";
+
+	/**
+	* Constructor
+	* @outputDir The output directory
+	* @projectTitle The title used in the HTML output
+	*/
+	component function init( required outputDir, string projectTitle="Untitled" ){
+		super.init();
+
+		variables.outputDir 	= arguments.outputDir;
+		variables.projectTitle 	= arguments.projectTitle;
+
+		return this;
+	}
+
+	/**
+	* Run this strategy
+	* @qMetaData The metadata
+	*/
+	component function run( required query qMetadata ){
+		ensureDirectory( getOutputDir() );
+		ensureDirectory( getOutputDir() & "/classes" );
+
+		//write the index template
+		var args = {
+			path 		 = getOutputDir() & "/index.json", 
+			template 	 = "#variables.static.TEMPLATE_PATH#/index.cfm", 
+			projectTitle = getProjectTitle()
+		};
+
+		// consider chainable methods, since that's how HTMLAPIStrategy works.
+		var classData = normalize( queryToArray( arguments.qMetadata ) );
+
+		serializeToFile(
+			getOutputDir() & "/index.json",
+			generateClassIndex( classData )
+		);
+
+		classData.each( ( class ) => {
+			serializeToFile(
+				getOutputDir() & "/classes/#class.name#.json",
+				class
+			);
+		});
+
+		return this;
+	}
+
+	/**
+	 * Marshall component metadata into a class index file.
+	 * This will be spit into an `index.json` file at the root of the output directory.
+	 *
+	 * @classData 
+	 */
+	package struct function generateClassIndex( required array classData ){
+		var classMap = arguments.classData.map( ( class ) => {
+			return {
+				"name" : class.name,
+				"path" : "#getOutputDir()#/classes/#class.name#.json"
+			}
+		});
+		return {
+			"packages" : classMap
+		}
+	}
+
+	package array function normalize( required array classData ){
+		var componentMeta = [ "hint", "extends", "functions", "fullname", "properties", "remoteAddress", "type", "hashCode", "name", "path" ];
+		var functionMeta = [ "name", "hint", "description", "access", "closure", "owner", "position", "returnFormat", "returnType", "modifier", "parameters" ];
+		return arguments.classData.map( function( row ) {
+			/**
+			 * Marshall component metadata into attributes array.
+			 */
+			var metaAttributes = row.metadata.filter( ( key ) => {
+				return !arrayContainsNoCase( componentMeta, key );
+			});
+			/**
+			 * Marshall functions to match the designed schema;
+			 * including generating an "attributes" array of attributes not described elsewhere on the function.
+			 */
+			var metaFunctions = row.metadata.functions.map( ( method ) => {
+				return {
+					"returnType" : method.returnType,
+					"returnFormat" : method.returnFormat,
+					"parameters" : method.parameters,
+					"name" : method.name,
+					"hint" : method.keyExists( "hint" ) ? method.hint : "",
+					"description" : method.keyExists( "description" ) ? method.description : "",
+					"access" : method.access,
+					"position" : method.position,
+					"attributes" : method.filter( ( key ) => {
+						return !arrayContainsNoCase( functionMeta, key );
+					})
+				}
+			} );
+			return {
+				"name" : row.name,
+				"package" : row.package,
+				"type" : row.type,
+				"extends" : row.extends,
+				"fullextends" : row.fullextends,
+				"hint" : row.metadata.hint,
+				"attributes" : metaAttributes,
+				"functions" : metaFunctions
+			};
+		});
+	}
+
+
+	/**
+	 * Convert a query object to an array of structs.
+	 *
+	 * @data source query object
+	 */
+	private array function queryToArray( required query data ){
+		var converted = [];
+		for( var i = 1; i <= arguments.data.recordCount; i++ ){
+			converted.append( queryGetRow( arguments.data, i ) );
+		}
+		return converted;
+	}
+
+	/**
+	 * Serialize the given @data into JSON and write to @path.
+	 *
+	 * @path Full path and filename of the file to create or overwrite.
+	 * @data Must be JSON-compatible... so either an array or a struct.
+	 */
+	package function serializeToFile( required string path, required any data ){
+        fileWrite( arguments.path, serializeJSON( arguments.data, true ) );
+	}
+}

--- a/tests/resources/tmp/.gitignore
+++ b/tests/resources/tmp/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all but self.
+*
+!.gitignore

--- a/tests/resources/tmp/.gitignore
+++ b/tests/resources/tmp/.gitignore
@@ -1,3 +1,0 @@
-# Ignore all but self.
-*
-!.gitignore

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -1,0 +1,21 @@
+<cfsetting showDebugOutput="false">
+<!--- Executes all tests in the 'specs' folder with simple reporter by default --->
+<cfparam name="url.reporter" 		default="simple">
+<cfparam name="url.directory" 		default="tests.specs">
+<cfparam name="url.recurse" 		default="true" type="boolean">
+<cfparam name="url.bundles" 		default="">
+<cfparam name="url.labels" 			default="">
+<cfparam name="url.reportpath" 		default="#expandPath( "/tests/results" )#">
+<cfparam name="url.propertiesFilename" 	default="TEST.properties">
+<cfparam name="url.propertiesSummary" 	default="false" type="boolean">
+
+<!--- Code Coverage requires FusionReactor --->
+<cfparam name="url.coverageEnabled"					default="true">
+<cfparam name="url.coveragePathToCapture"			default="#expandPath( '/root' )#">
+<cfparam name="url.coverageWhitelist"				default="">
+<cfparam name="url.coverageBlacklist"				default="/testbox,/coldbox,/tests,/modules,Application.cfc,/index.cfm">
+<!---<cfparam name="url.coverageBrowserOutputDir"		default="#expandPath( '/tests/results/coverageReport' )#">--->
+<!---<cfparam name="url.coverageSonarQubeXMLOutputPath"	default="#expandPath( '/tests/results/SonarQubeCoverage.xml' )#">--->
+
+<!--- Include the TestBox HTML Runner --->
+<cfinclude template="/testbox/system/runners/HTMLRunner.cfm" >

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -5,6 +5,7 @@ component extends="testbox.system.BaseSpec"{
 
 	property name="HTMLOutputDir" default="/tests/resources/tmp/html";
 	property name="JSONOutputDir" default="/tests/resources/tmp/json";
+	property name="XMIOutputFile" default="/tests/resources/tmp/uml/XMITestFile.uml";
 
 /*********************************** LIFE CYCLE Methods ***********************************/
 
@@ -25,6 +26,7 @@ component extends="testbox.system.BaseSpec"{
 			beforeEach( function() {
 				resetTmpDirectory( variables.HTMLOutputDir );
 				resetTmpDirectory( variables.JSONOutputDir );
+				resetTmpDirectory( getDirectoryFromPath( variables.XMIOutputFile ) );
 
 				variables.docbox = new docbox.DocBox();
 			});
@@ -88,6 +90,41 @@ component extends="testbox.system.BaseSpec"{
 					.addStrategy(
 						"docbox.strategy.json.JSONAPIStrategy",
 						{ outputDir 		= variables.JSONOutputDir }
+					)
+					.addStrategy(
+						"docbox.strategy.uml2tools.XMIStrategy",
+						{ outputFile 		= variables.XMIOutputFile }
+					)
+					.generate(
+						source = expandPath( "/tests" ),
+						mapping = "tests",
+						excludes="(coldbox|build\-docbox)"
+					);
+
+				var allClassesFile = variables.HTMLOutputDir & "/allclasses-frame.html";
+				expect( fileExists( allClassesFile ) )
+					.toBeTrue( "should generate allclasses-frame.html file to list all classes"  );
+
+				var results = directoryList( variables.JSONOutputDir, true, "name" );
+				expect( results.len() ).toBeGT( 0 );
+
+				expect( arrayContainsNoCase( results, "overview-summary.json" ) )
+					.toBeTrue( "should generate overview-summary.json class index file" );
+			});
+
+			it( "Supports strategy aliases", function(){
+				variables.docbox
+					.addStrategy(
+						"HTML",
+						{ outputDir 		= variables.HTMLOutputDir }
+					)
+					.addStrategy(
+						"JSON",
+						{ outputDir 		= variables.JSONOutputDir }
+					)
+					.addStrategy(
+						"XMI",
+						{ outputFile 		= variables.XMIOutputFile }
 					)
 					.generate(
 						source = expandPath( "/tests" ),

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -113,19 +113,11 @@ component extends="testbox.system.BaseSpec"{
 			});
 
 			it( "Supports strategy aliases", function(){
+
 				variables.docbox
-					.addStrategy(
-						"HTML",
-						{ outputDir 		= variables.HTMLOutputDir }
-					)
-					.addStrategy(
-						"JSON",
-						{ outputDir 		= variables.JSONOutputDir }
-					)
-					.addStrategy(
-						"XMI",
-						{ outputFile 		= variables.XMIOutputFile }
-					)
+					.addStrategy( "HTML", { outputDir 		= variables.HTMLOutputDir } )
+					.addStrategy( "JSON", { outputDir 		= variables.JSONOutputDir } )
+					.addStrategy( "XMI", { outputFile 		= variables.XMIOutputFile } )
 					.generate(
 						source = expandPath( "/tests" ),
 						mapping = "tests",

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -1,0 +1,122 @@
+/**
+* My BDD Test
+*/
+component extends="testbox.system.BaseSpec"{
+
+	property name="HTMLOutputDir" default="/tests/resources/tmp/html";
+	property name="JSONOutputDir" default="/tests/resources/tmp/json";
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	// executes before all suites+specs in the run() method
+	function beforeAll(){
+	}
+
+	// executes after all suites+specs in the run() method
+	function afterAll(){
+		structDelete( variables, "docbox" );
+	}
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run( testResults, testBox ){
+		// all your suites go here.
+		describe( "DocBox", function(){
+			beforeEach( function() {
+				resetTmpDirectory( variables.HTMLOutputDir );
+				resetTmpDirectory( variables.JSONOutputDir );
+
+				variables.docbox = new docbox.DocBox();
+			});
+
+			it( "Works with single strategy", function(){
+				variables.docbox
+					.addStrategy(
+						"docbox.strategy.api.HTMLAPIStrategy",
+						{
+							outputDir 		= variables.HTMLOutputDir
+						}
+					)
+					.generate(
+						source = expandPath( "/tests" ),
+						mapping = "tests",
+						excludes="(coldbox|build\-docbox)"
+					);
+
+				var allClassesFile = variables.HTMLOutputDir & "/allclasses-frame.html";
+				expect( fileExists( allClassesFile ) )
+					.toBeTrue( "should generate allclasses-frame.html file to list all classes"  );
+			});
+
+			it( "throws if no strategy is set", function(){
+				expect( function() {
+					variables.docbox
+						.generate(
+							source = expandPath( "/tests" ),
+							mapping = "tests",
+							excludes="(coldbox|build\-docbox)"
+						);
+				}).toThrow( "StrategyNotSetException" );
+			});
+
+			it( "lets me set my own strategy", function(){
+				expect( function() {
+					var myDemoStrategy = getMockBox().createStub( extends = "docbox.strategy.AbstractTemplateStrategy" );
+					myDemoStrategy.$(
+						method = "run",
+						returns = new docbox.strategy.AbstractTemplateStrategy(),
+						callLogging = true
+					);
+					variables.docbox
+						.setStrategy( myDemoStrategy )
+						.generate(
+							source = expandPath( "/tests" ),
+							mapping = "tests",
+							excludes="(coldbox|build\-docbox)"
+						);
+
+					expect( myDemoStrategy.$once( "run" ) ).toBeTrue( "should execute strategy.run()");
+				}).notToThrow();
+			});
+
+			it( "Works with multiple strategies", function(){
+				variables.docbox
+					.addStrategy(
+						"docbox.strategy.api.HTMLAPIStrategy",
+						{ outputDir 		= variables.HTMLOutputDir }
+					)
+					.addStrategy(
+						"docbox.strategy.json.JSONAPIStrategy",
+						{ outputDir 		= variables.JSONOutputDir }
+					)
+					.generate(
+						source = expandPath( "/tests" ),
+						mapping = "tests",
+						excludes="(coldbox|build\-docbox)"
+					);
+
+				var allClassesFile = variables.HTMLOutputDir & "/allclasses-frame.html";
+				expect( fileExists( allClassesFile ) )
+					.toBeTrue( "should generate allclasses-frame.html file to list all classes"  );
+
+				var results = directoryList( variables.JSONOutputDir, true, "name" );
+				debug( results );
+				expect( results.len() ).toBeGT( 0 );
+
+				expect( arrayContainsNoCase( results, "index.json" ) )
+					.toBeTrue( "should generate index.json class index file" );
+			});
+
+		});
+	}
+
+	function resetTmpDirectory( directory ){
+		// empty the directory so we know if it has been populated
+		if ( directoryExists( arguments.directory ) ){
+			directoryDelete( arguments.directory, true );
+		}
+		directoryCreate( arguments.directory );
+	}
+
+}
+

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -100,11 +100,10 @@ component extends="testbox.system.BaseSpec"{
 					.toBeTrue( "should generate allclasses-frame.html file to list all classes"  );
 
 				var results = directoryList( variables.JSONOutputDir, true, "name" );
-				debug( results );
 				expect( results.len() ).toBeGT( 0 );
 
-				expect( arrayContainsNoCase( results, "index.json" ) )
-					.toBeTrue( "should generate index.json class index file" );
+				expect( arrayContainsNoCase( results, "overview-summary.json" ) )
+					.toBeTrue( "should generate overview-summary.json class index file" );
 			});
 
 		});

--- a/tests/specs/HTMLAPIStrategyTest.cfc
+++ b/tests/specs/HTMLAPIStrategyTest.cfc
@@ -1,0 +1,73 @@
+/**
+* My BDD Test
+*/
+component extends="testbox.system.BaseSpec"{
+
+	property name="testOutputDir" default="/tests/resources/tmp/html";
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	// executes before all suites+specs in the run() method
+	function beforeAll(){
+		variables.docbox = new docbox.DocBox(
+			strategy = "docbox.strategy.api.HTMLAPIStrategy",
+			properties={ 
+				projectTitle 	= "DocBox Tests",
+				outputDir 		= variables.testOutputDir
+			}
+		);
+	}
+
+	// executes after all suites+specs in the run() method
+	function afterAll(){
+		structDelete( variables, "docbox" );
+	}
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+		// all your suites go here.
+		describe( "HTMLAPIStrategy", function(){
+
+			beforeEach( function() {
+				// empty the directory so we know if it has been populated
+				if ( directoryExists( variables.testOutputDir ) ){
+					directoryDelete( variables.testOutputDir, true );
+				}
+				directoryCreate( variables.testOutputDir );
+			});
+
+			it( "can run without failure", function(){
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+			});
+
+			it( "produces JSON output in the correct directory", function() {
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+				
+				var allClassesFile = variables.testOutputDir & "/allclasses-frame.html";
+				expect( fileExists( allClassesFile ) )
+					.toBeTrue( "should generate allclasses-frame.html file to list all classes"  );
+
+				var allClassesHTML = fileRead( allClassesFile );
+				expect( allClassesHTML )
+					.toInclude( "HTMLAPIStrategyTest", "should document HTMLAPIStrategyTest.cfc in list of classes." );
+				
+				var testFile = variables.testOutputDir & "/tests/specs/HTMLAPIStrategyTest.html";
+				expect( fileExists( testFile ) )
+					.toBeTrue( "should generate #testFile# to document HTMLAPIStrategyTest.cfc")
+
+			});
+
+		});
+	}
+
+}
+

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -83,6 +83,26 @@ component extends="testbox.system.BaseSpec"{
 
 			});
 
+			it( "produces package-summary.json file for each 'package' level", function() {
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+
+				var results = directoryList( variables.testOutputDir, true, "name" );
+				debug( results );
+				expect( results.len() ).toBeGT( 0 );
+
+				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/index.json" ) )
+					.toBeTrue( "should generate package summary file" );
+
+				var packageSummary = fileRead( variables.testOutputDir & "/classes/tests/specs/index.json" );
+
+				expect( deSerializeJSON( packageSummary ) ).toBeTypeOf( "struct" );
+
+			});
+
 		});
 	}
 

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -59,12 +59,10 @@ component extends="testbox.system.BaseSpec"{
 				debug( results );
 				expect( results.len() ).toBeGT( 0 );
 
-				expect( arrayContainsNoCase( results, "index.json" ) )
+				expect( arrayContainsNoCase( results, "overview-summary.json" ) )
 					.toBeTrue( "should generate index.json class index file" );
-				expect( arrayContainsNoCase( results, "classes" ) )
-					.toBeTrue( "should generate classes/ directory for class documentation");
 				expect( arrayContainsNoCase( results, "JSONAPIStrategyTest.json" ) )
-					.toBeTrue( "should generate classes/JSONAPIStrategyTest.json to document JSONAPIStrategyTest.cfc")
+					.toBeTrue( "should generate JSONAPIStrategyTest.json to document JSONAPIStrategyTest.cfc")
 
 			});
 
@@ -74,12 +72,14 @@ component extends="testbox.system.BaseSpec"{
 					mapping = "tests",
 					excludes="(coldbox|build\-docbox)"
 				);
+				expect( directoryExists( variables.testOutputDir & "/tests/specs" ) )
+					.toBeTrue( "should generate tests/specs directory for output" );
 
-				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/JSONAPIStrategyTest.json" ) )
-					.toBeTrue( "should generate documentation in nested hierarchy according to source .cfc file" );
+				expect( fileExists( variables.testOutputDir & "/tests/specs/JSONAPIStrategyTest.json" ) )
+					.toBeTrue( "should generate JSONAPIStrategyTest.json documentation file" );
 
-				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/HTMLAPIStrategyTest.json" ) )
-					.toBeTrue( "should generate documentation in nested hierarchy according to source .cfc file" );
+				expect( fileExists( variables.testOutputDir & "/tests/specs/HTMLAPIStrategyTest.json" ) )
+					.toBeTrue( "should generate HTMLAPIStrategyTest.json documentation file" );
 
 			});
 
@@ -90,16 +90,23 @@ component extends="testbox.system.BaseSpec"{
 					excludes="(coldbox|build\-docbox)"
 				);
 
-				var results = directoryList( variables.testOutputDir, true, "name" );
-				debug( results );
-				expect( results.len() ).toBeGT( 0 );
-
-				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/index.json" ) )
+				expect( fileExists( variables.testOutputDir & "/tests/specs/package-summary.json" ) )
 					.toBeTrue( "should generate package summary file" );
 
-				var packageSummary = fileRead( variables.testOutputDir & "/classes/tests/specs/index.json" );
+				var packageSummary = deSerializeJSON( fileRead( variables.testOutputDir & "/tests/specs/package-summary.json" ) );
 
-				expect( deSerializeJSON( packageSummary ) ).toBeTypeOf( "struct" );
+				expect( packageSummary ).toBeTypeOf( "struct" )
+										.toHaveKey( "classes" );
+
+				expect( packageSummary.classes ).toBeTypeOf( "array" );
+				expect( packageSummary.classes.len() ).toBeGT( 0, "should have a few documented packages" );
+				packageSummary.classes.each( ( class ) => {
+					expect( class ).toBeTypeOf( "struct" )
+									.toHaveKey( "path" )
+									.toHaveKey( "name" );
+					expect( listLast( class.path, "." ) ).toBe( "json" );
+					expect( fileExists( variables.testOutputDir & "/" & class.path ) ).toBeTrue( "should point to existing class documentation file" );
+				});
 
 			});
 

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -1,0 +1,69 @@
+/**
+* My BDD Test
+*/
+component extends="testbox.system.BaseSpec"{
+
+	property name="testOutputDir" default="/tests/resources/tmp";
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	// executes before all suites+specs in the run() method
+	function beforeAll(){
+		variables.docbox = new docbox.DocBox(
+			strategy = "docbox.strategy.json.JSONAPIStrategy",
+			properties={ 
+				projectTitle 	= "DocBox Tests",
+				outputDir 		= variables.testOutputDir
+			}
+		);
+	}
+
+	// executes after all suites+specs in the run() method
+	function afterAll(){
+		structDelete( variables, "docbox" );
+	}
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run( testResults, testBox, foo = "yellow" ) testRole="Administrator"{
+		// all your suites go here.
+		describe( "JSONAPIStrategy", function(){
+
+			it( "can run without failure", function(){
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+			});
+
+			it( "produces JSON output in the correct directory", function() {
+				// empty the directory so we know if it has been populated
+				directoryDelete( variables.testOutputDir, true );
+				directoryCreate( variables.testOutputDir );
+
+
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+
+				var results = directoryList( variables.testOutputDir, true, "name" );
+				debug( results );
+				expect( results.len() ).toBeGT( 0 );
+
+				expect( arrayContainsNoCase( results, "index.json" ) )
+					.toBeTrue( "should generate index.json class index file" );
+				expect( arrayContainsNoCase( results, "classes" ) )
+					.toBeTrue( "should generate classes/ directory for class documentation");
+				expect( arrayContainsNoCase( results, "JSONAPIStrategyTest.json" ) )
+					.toBeTrue( "should generate classes/JSONAPIStrategyTest.json to document JSONAPIStrategyTest.cfc")
+
+			});
+
+		});
+	}
+
+}
+

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -56,7 +56,6 @@ component extends="testbox.system.BaseSpec"{
 				);
 
 				var results = directoryList( variables.testOutputDir, true, "name" );
-				debug( results );
 				expect( results.len() ).toBeGT( 0 );
 
 				expect( arrayContainsNoCase( results, "overview-summary.json" ) )

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -68,6 +68,21 @@ component extends="testbox.system.BaseSpec"{
 
 			});
 
+			it( "Produces the correct hierarchy of class documentation files", function() {
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+
+				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/JSONAPIStrategyTest.json" ) )
+					.toBeTrue( "should generate documentation in nested hierarchy according to source .cfc file" );
+
+				expect( directoryExists( variables.testOutputDir & "/classes/tests/specs/HTMLAPIStrategyTest.json" ) )
+					.toBeTrue( "should generate documentation in nested hierarchy according to source .cfc file" );
+
+			});
+
 		});
 	}
 

--- a/tests/specs/JSONAPIStrategyTest.cfc
+++ b/tests/specs/JSONAPIStrategyTest.cfc
@@ -3,7 +3,7 @@
 */
 component extends="testbox.system.BaseSpec"{
 
-	property name="testOutputDir" default="/tests/resources/tmp";
+	property name="testOutputDir" default="/tests/resources/tmp/json";
 
 /*********************************** LIFE CYCLE Methods ***********************************/
 
@@ -25,24 +25,30 @@ component extends="testbox.system.BaseSpec"{
 
 /*********************************** BDD SUITES ***********************************/
 
-	function run( testResults, testBox, foo = "yellow" ) testRole="Administrator"{
+	function run(){
 		// all your suites go here.
 		describe( "JSONAPIStrategy", function(){
 
+			beforeEach( function() {
+				// empty the directory so we know if it has been populated
+				if ( directoryExists( variables.testOutputDir ) ){
+					directoryDelete( variables.testOutputDir, true );
+				}
+				directoryCreate( variables.testOutputDir );
+			});
+
 			it( "can run without failure", function(){
-				variables.docbox.generate(
-					source = expandPath( "/tests" ),
-					mapping = "tests",
-					excludes="(coldbox|build\-docbox)"
-				);
+				expect( function() {
+					variables.docbox.generate(
+						source = expandPath( "/tests" ),
+						mapping = "tests",
+						excludes="(coldbox|build\-docbox)"
+					)
+				}
+				).notToThrow();
 			});
 
 			it( "produces JSON output in the correct directory", function() {
-				// empty the directory so we know if it has been populated
-				directoryDelete( variables.testOutputDir, true );
-				directoryCreate( variables.testOutputDir );
-
-
 				variables.docbox.generate(
 					source = expandPath( "/tests" ),
 					mapping = "tests",

--- a/tests/specs/XMIStrategyTest.cfc
+++ b/tests/specs/XMIStrategyTest.cfc
@@ -1,0 +1,78 @@
+/**
+* My BDD Test
+*/
+component extends="testbox.system.BaseSpec"{
+
+	property name="testOutputFile" default="/tests/resources/tmp/uml/XMITestFile.uml";
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	// executes before all suites+specs in the run() method
+	function beforeAll(){
+		variables.docbox = new docbox.DocBox(
+			strategy = "docbox.strategy.uml2tools.XMIStrategy",
+			properties={ 
+				projectTitle 	= "DocBox Tests",
+				outputFile 		= variables.testOutputFile
+			}
+		);
+		
+	}
+
+	// executes after all suites+specs in the run() method
+	function afterAll(){
+		if ( fileExists( variables.testOutputFile ) ){
+			fileDelete( variables.testOutputFile );
+		}
+
+		var testDir = getDirectoryFromPath( variables.testOutputFile );
+		if ( directoryExists( variables.testOutputFile ) ){
+			directoryDelete( variables.testOutputFile );
+		}
+
+		structDelete( variables, "docbox" );
+	}
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+		// all your suites go here.
+		describe( "XMLStrategy", function(){
+
+			beforeEach( function() {
+				// delete the test file so we know if it has been created during test runs
+				if ( fileExists( variables.testOutputFile ) ){
+					fileDelete( variables.testOutputFile );
+				}
+			});
+
+			it( "can run without failure", function(){
+				expect( function() {
+					variables.docbox.generate(
+						source = expandPath( "/tests" ),
+						mapping = "tests",
+						excludes="(coldbox|build\-docbox)"
+					)
+				}
+				).notToThrow();
+			});
+
+			it( "produces UML output in the correct file", function() {
+				variables.docbox.generate(
+					source = expandPath( "/tests" ),
+					mapping = "tests",
+					excludes="(coldbox|build\-docbox)"
+				);
+
+				expect( fileExists( variables.testOutputFile ) )
+					.toBeTrue( "Should generate the UML diagram file " );
+
+				var umlContent = fileRead( variables.testOutputFile );
+				expect( UMLContent ).toInclude( 'name="XMIStrategyTest">', "should find and document the XMIStrategyTest.cfc class in tests/specs directory" );
+
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
## Changes

1. Adds a `JSONAPIStrategy` for outputting class documentation in machine-readable JSON format.
2. Adds tests for all three output strategies
  * `JSONAPIStrategyTest.cfc`
  * `HTMLAPIStrategyTest.cfc`
  * `XMIStrategyTest.cfc`
3. Fixes an error in `AbstractTemplateStrategyTest.cfc`` so the XMIStrategy actually runs without error.
4. Adds support for generating multiple strategies in one `.generate()` call
5. Adds strategy `alias` which greatly simplifies the setting of an output strategy.

## New JSONAPIStrategy

This generates a suite of JSON files which describe the project.

1. `index.json` a list of classes with `name` and `path`. The `path` points to the full class documentation.
2. `classes/` directory which will contain a hierarchy of class documentation.
3. `classes/myClass.json` file containing metadata about the class.

### Using the JSON API Strategy for Class Documentation

```js
variables.docbox = new docbox.DocBox(
    strategy = "docbox.strategy.json.JSONAPIStrategy",
    properties={ 
        projectTitle               = "DocBox Tests",
        outputDir                  = expandPath( "/resources/tmp/docs")
    }
);
variables.docbox.generate(
    source = expandPath( "/app" ),
    mapping = "tests",
    excludes="(coldbox|build\-docbox)"
)
```

The two things I'm not sure on at the moment:

1. Should I commit the JSON schema directory to this repo?
2. Should the JSON output produce a directory hierarchy, similar to the HTML output?

(I'm thinking the answer is YES to both questions...)

## New Testing Framework

Adds basic "it runs without error and generates files/directories as expected" tests.

We can easily run these tests in a Github Action or Travis task via `box install && box testbox run`.

![Screenshot from 2020-11-02 22-58-06](https://user-images.githubusercontent.com/8106227/97950703-cd685000-1d65-11eb-9522-0681493af2e0.png)

## Fix for XMI Strategy

Can you spot the error?

```
var qPackages = new Query( dbtype="query", md=arguments.qMetadata, sql="
SELECT DISTINCT
    package
FROM
    md..." )
.execute()
.getResult();

for( var thisRow in qPackages ){
...
var aPackage = listToArray( thisRow, "." );
```

`thisRow` is not a string - it's a struct. A query row. Changed to `thisRow[ "package" ]` to fix an error upon running `.generate()`.

## Multiple Output Strategies Support

DocBox now supports generating multiple documentation formats at once via the `addStrategy()` method.

```
variables.docbox
    .addStrategy(
        "docbox.strategy.api.HTMLAPIStrategy",
        { outputDir 		= "/docs" }
    )
    .addStrategy(
        "docbox.strategy.json.JSONAPIStrategy",
        { outputDir 		= "/docs" }
    )
    .addStrategy(
        "docbox.strategy.uml2tools.XMIStrategy",
        { outputFile 		= "/docs/XMIOutput.uml" }
    )
    .generate(
        source = expandPath( "/tests" ),
        mapping = "tests",
        excludes="(coldbox|build\-docbox)"
    );
```

## Strategy Aliases

Strategy aliases can now be used instead of the full strategy path when setting the output strategy. This resolves one of the biggest tripping points I found when first getting started with DocBox ~4 years ago.

* Instead of `docbox.strategy.api.HTMLAPIStrategy`, use `HTML` or `HTMLAPIStrategy`
* Instead of `docbox.strategy.json.JSONAPIStrategy`, use `JSON` or `JSONAPIStrategy`
* Instead of `docbox.strategy.uml2tools.XMIStrategy`, use `XMI` or `XMIStrategy`

Here's how that looks in our test spec:

```
variables.docbox
    .addStrategy( "HTML", { outputDir = "/docs" } )
    .addStrategy( "JSON", { outputDir = "/docs" } )
    .addStrategy( "XMI", { outputFile = "/docs/XMIOutput.uml" } )
    .generate(
        source = expandPath( "/tests" ),
        mapping = "tests",
        excludes="(coldbox|build\-docbox)"
    );
```
