### PR TITLE
improve: Format component/property/method hints into paragraph format

### DIFF
--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -112,7 +112,10 @@ component accessors="true" {
 	){
 		// verify we have at least one strategy defined, if not, auto add the HTML strategy
 		if ( isNull( getStrategies() ) || !getStrategies().len() ) {
-			this.addStrategy( strategy : "HTML", properties : variables.properties );
+			this.addStrategy(
+				strategy  : "HTML",
+				properties: variables.properties
+			);
 		}
 
 		// inflate the incoming input and mappings

--- a/strategy/api/resources/templates/class.cfm
+++ b/strategy/api/resources/templates/class.cfm
@@ -154,7 +154,7 @@ Class
 
 <cfif StructKeyExists(arguments.metadata, "hint")>
 <div id="class-hint">
-	<p>#arguments.metadata.hint#</p>
+	<p>#formatLineBreaks( arguments.metadata.hint )#</p>
 </div>
 </cfif>
 
@@ -396,7 +396,7 @@ Class
 	<br><br>
 
 	<cfif StructKeyExists(local.init, "hint")>
-	<p>#local.init.hint#</p>
+	<p>#formatLineBreaks( local.init.hint )#</p>
 	</cfif>
 
 	<cfif StructKeyExists(local.init, "parameters") AND ArrayLen(local.init.parameters)>
@@ -436,7 +436,7 @@ Class
 
 		<br><br>
 		<cfif StructKeyExists(local.prop, "hint") AND Len(local.prop.hint)>
-			<p>#local.prop.hint#</p>
+			<p>#formatLineBreaks( local.prop.hint )#</p>
 		</cfif>
 
 		<dl>
@@ -485,7 +485,7 @@ Class
 	<br><br>
 
 	<cfif StructKeyExists(local.func, "hint") AND Len(local.func.hint)>
-		<p>#local.func.hint#</p>
+		<p>#formatLineBreaks( local.func.hint )#</p>
 	</cfif>
 
 	<cfif StructKeyExists(local.func, "deprecated") AND isSimplevalue(local.func.deprecated)>
@@ -687,6 +687,28 @@ Class
 			return list;
 		}
 		*/
+
+		/**
+		 * Improved version of Ben Forta's "ParagraphFormat2" method on cflib.
+		 * 
+		 * @cite https://cflib.org/udf/ParagraphFormat2
+		 * @param string      The string to format. (Required)
+		 * @return Returns a string. 
+		 * @author Ben Forta (ben@forta.com) 
+		 * @version 3, June 26, 2002 
+		 */
+		function formatLineBreaks( string val ){
+			// first make Windows style into Unix style
+			val = replace(val,chr(13)&chr(10),chr(10),"ALL");
+			// now make Macintosh style into Unix style
+			val = replace(val,chr(13),chr(10),"ALL");
+			// tabs
+			val = replace(val,chr(9),"&nbsp;&nbsp;&nbsp;&nbsp;","ALL");
+			// double line breaks
+			val = replace(val,chr(10)&chr(10),"</p><p>","ALL");
+			// single line breaks
+			return replace(val,chr(10),"</p><p>","ALL");
+		}
 
 		function writeClassLink(package, name, qMetaData, format)
 		{

--- a/strategy/api/resources/templates/class.cfm
+++ b/strategy/api/resources/templates/class.cfm
@@ -699,15 +699,15 @@ Class
 		 */
 		function formatLineBreaks( string val ){
 			// first make Windows style into Unix style
-			val = replace(val,chr(13)&chr(10),chr(10),"ALL");
+			arguments.val = replace(arguments.val,chr(13)&chr(10),chr(10),"ALL");
 			// now make Macintosh style into Unix style
-			val = replace(val,chr(13),chr(10),"ALL");
+			arguments.val = replace(arguments.val,chr(13),chr(10),"ALL");
 			// tabs
-			val = replace(val,chr(9),"&nbsp;&nbsp;&nbsp;&nbsp;","ALL");
+			arguments.val = replace(arguments.val,chr(9),"&nbsp;&nbsp;&nbsp;&nbsp;","ALL");
 			// double line breaks
-			val = replace(val,chr(10)&chr(10),"</p><p>","ALL");
+			arguments.val = replace(arguments.val,chr(10)&chr(10),"</p><p>","ALL");
 			// single line breaks
-			return replace(val,chr(10),"</p><p>","ALL");
+			return replace(arguments.val,chr(10),"</p><p>","ALL");
 		}
 
 		function writeClassLink(package, name, qMetaData, format)

--- a/strategy/uml2tools/XMIStrategy.cfc
+++ b/strategy/uml2tools/XMIStrategy.cfc
@@ -1,123 +1,144 @@
-<cfcomponent output="false" hint="Strategy for generating the .uml file for Eclipse UML2Tools to generate diagrams from"
-				extends="docbox.strategy.AbstractTemplateStrategy" >
+<cfcomponent
+	output ="false"
+	hint   ="Strategy for generating the .uml file for Eclipse UML2Tools to generate diagrams from"
+	extends="docbox.strategy.AbstractTemplateStrategy"
+>
+	<!------------------------------------------- PUBLIC ------------------------------------------->
 
-<!------------------------------------------- PUBLIC ------------------------------------------->
-
-<cfscript>
-	instance.static.TEMPLATE_PATH = "/docbox/strategy/uml2tools/resources/templates";
-</cfscript>
-
-<cffunction name="init" hint="Constructor" access="public" returntype="XMIStrategy" output="false">
-	<cfargument name="outputFile" hint="absolute path to the output file. File should end in .uml, if it doesn' it will be added." type="string" required="Yes">
 	<cfscript>
+	instance.static.TEMPLATE_PATH = "/docbox/strategy/uml2tools/resources/templates";
+	</cfscript>
+
+	<cffunction name="init" hint="Constructor" access="public" returntype="XMIStrategy" output="false">
+		<cfargument
+			name    ="outputFile"
+			hint    ="absolute path to the output file. File should end in .uml, if it doesn' it will be added."
+			type    ="string"
+			required="Yes"
+		>
+		<cfscript>
 		super.init();
 
-		if(NOT arguments.outputFile.endsWith(".uml"))
-		{
+		if ( NOT arguments.outputFile.endsWith( ".uml" ) ) {
 			arguments.outputFile &= ".uml";
 		}
 
-		setOutputFile(arguments.outputFile);
+		setOutputFile( arguments.outputFile );
 
 		return this;
-	</cfscript>
-</cffunction>
+		</cfscript>
+	</cffunction>
 
-<cffunction name="run" hint="run this strategy" access="public" returntype="void" output="false">
-	<cfargument name="qMetadata" hint="the meta data query" type="query" required="Yes">
-	<cfscript>
-		var basePath = getDirectoryFromPath(getMetaData(this).path);
-		var args = 0;
-		var packages = buildPackageTree(arguments.qMetadata, true);
-
-		ensureDirectory(getDirectoryFromPath(getOutputFile()));
-
-		//write the index template
-		args = {path=getOutputFile()
-				,template="#instance.static.TEMPLATE_PATH#/template.uml"
-				,packages = packages
-				,qMetadata = qMetadata
-				};
-		writeTemplate(argumentCollection=args);
-    </cfscript>
-</cffunction>
-
-<!------------------------------------------- PACKAGE ------------------------------------------->
-
-<!------------------------------------------- PRIVATE ------------------------------------------->
-
-<cffunction name="determineProperties" hint="We will make the assumption that is there is a get & set function with the same name, its a property" access="private" returntype="query" output="false">
-	<cfargument name="meta" hint="the metadata for a class" type="struct" required="Yes">
-	<cfargument name="package" hint="the current package" type="string" required="Yes">
-	<cfscript>
-		var qFunctions = buildFunctionMetaData(arguments.meta);
-		var qProperties = QueryNew("name, access, type, generic");
-		//is is used for boolean properties
-		var qGetters = getMetaSubQuery(qFunctions, "LOWER(name) LIKE 'get%' OR LOWER(name) LIKE 'is%'");
-		var qSetters = 0;
-		var propertyName = 0;
-		var setterMeta = 0;
-		var getterMeta = 0;
-		var generics = 0;
-    </cfscript>
-	<cfloop query="qGetters">
+	<cffunction name="run" hint="run this strategy" access="public" returntype="void" output="false">
+		<cfargument name="qMetadata" hint="the meta data query" type="query" required="Yes">
 		<cfscript>
-			if(LCase(name).startsWith("get"))
-			{
-				propertyName = replaceNoCase(name, "get", "");
+		var basePath = getDirectoryFromPath( getMetadata( this ).path );
+		var args     = 0;
+		var packages = buildPackageTree( arguments.qMetadata, true );
+
+		ensureDirectory( getDirectoryFromPath( getOutputFile() ) );
+
+		// write the index template
+		args = {
+			path      : getOutputFile(),
+			template  : "#instance.static.TEMPLATE_PATH#/template.uml",
+			packages  : packages,
+			qMetadata : qMetadata
+		};
+		writeTemplate( argumentCollection = args );
+		</cfscript>
+	</cffunction>
+
+	<!------------------------------------------- PACKAGE ------------------------------------------->
+
+	<!------------------------------------------- PRIVATE ------------------------------------------->
+
+	<cffunction
+		name      ="determineProperties"
+		hint      ="We will make the assumption that is there is a get & set function with the same name, its a property"
+		access    ="private"
+		returntype="query"
+		output    ="false"
+	>
+		<cfargument name="meta" hint="the metadata for a class" type="struct" required="Yes">
+		<cfargument name="package" hint="the current package" type="string" required="Yes">
+		<cfscript>
+		var qFunctions  = buildFunctionMetaData( arguments.meta );
+		var qProperties = queryNew( "name, access, type, generic" );
+		// is is used for boolean properties
+		var qGetters    = getMetaSubQuery(
+			qFunctions,
+			"LOWER(name) LIKE 'get%' OR LOWER(name) LIKE 'is%'"
+		);
+		var qSetters     = 0;
+		var propertyName = 0;
+		var setterMeta   = 0;
+		var getterMeta   = 0;
+		var generics     = 0;
+		</cfscript>
+		<cfloop query="qGetters">
+			<cfscript>
+			if ( lCase( name ).startsWith( "get" ) ) {
+				propertyName = replaceNoCase( name, "get", "" );
+			} else {
+				propertyName = replaceNoCase( name, "is", "" );
 			}
-			else
-			{
-				propertyName = replaceNoCase(name, "is", "");
-			}
 
-			qSetters = getMetaSubQuery(qFunctions, "LOWER(name) = LOWER('set#propertyName#')");
-			getterMeta = structCopy(metadata);
+			qSetters = getMetaSubQuery(
+				qFunctions,
+				"LOWER(name) = LOWER('set#propertyName#')"
+			);
+			getterMeta = structCopy( metadata );
 
-			//lets just take getter generics, easier to do.
-			generics = getGenericTypes(metadata, arguments.package);
+			// lets just take getter generics, easier to do.
+			generics = getGenericTypes( metadata, arguments.package );
 
-			if(qSetters.recordCount)
-			{
+			if ( qSetters.recordCount ) {
 				setterMeta = qSetters.metadata;
 
-				if(structKeyExists(setterMeta, "parameters")
-					AND arrayLen(setterMeta.parameters) eq 1
-					AND setterMeta.parameters[1].type eq getterMeta.returnType
-					)
-				{
-					if(setterMeta.access eq "public" OR getterMeta.access eq "public")
-					{
+				if (
+					structKeyExists( setterMeta, "parameters" )
+					AND arrayLen( setterMeta.parameters ) eq 1
+					AND setterMeta.parameters[ 1 ].type eq getterMeta.returnType
+				) {
+					if ( setterMeta.access eq "public" OR getterMeta.access eq "public" ) {
 						access = "public";
-					}
-					else if(setterMeta.access eq "package" OR getterMeta.access eq "package")
-					{
+					} else if ( setterMeta.access eq "package" OR getterMeta.access eq "package" ) {
 						access = "package";
-					}
-					else
-					{
+					} else {
 						access = "private";
 					}
-					queryAddRow(qProperties);
-					//lower case the front
-					querySetCell(qProperties, "name", rereplace(propertyName, "([A-Z]*)(.*)", "\L\1\E\2"));
-					querySetCell(qProperties, "access", access);
-					querySetCell(qProperties, "type", getterMeta.returntype);
-					querySetCell(qProperties, "generic", generics);
+					queryAddRow( qProperties );
+					// lower case the front
+					querySetCell(
+						qProperties,
+						"name",
+						reReplace(
+							propertyName,
+							"([A-Z]*)(.*)",
+							"\L\1\E\2"
+						)
+					);
+					querySetCell( qProperties, "access", access );
+					querySetCell(
+						qProperties,
+						"type",
+						getterMeta.returntype
+					);
+					querySetCell( qProperties, "generic", generics );
 				}
 			}
-        </cfscript>
-	</cfloop>
-	<cfreturn qProperties />
-</cffunction>
+			</cfscript>
+		</cfloop>
+		<cfreturn qProperties/>
+	</cffunction>
 
-<cffunction name="getOutputFile" access="private" returntype="string" output="false">
-	<cfreturn instance.outputFile />
-</cffunction>
+	<cffunction name="getOutputFile" access="private" returntype="string" output="false">
+		<cfreturn instance.outputFile/>
+	</cffunction>
 
-<cffunction name="setOutputFile" access="private" returntype="void" output="false">
-	<cfargument name="outputFile" type="string" required="true">
-	<cfset instance.outputFile = arguments.outputFile />
-</cffunction>
-
+	<cffunction name="setOutputFile" access="private" returntype="void" output="false">
+		<cfargument name="outputFile" type="string" required="true">
+		<cfset instance.outputFile = arguments.outputFile/>
+	</cffunction>
 </cfcomponent>

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -1,15 +1,19 @@
 /**
-* Copyright 2015 Ortus Solutions, Corp
-* www.ortussolutions.com
-**************************************************************************************
-*/
-component{
+ * Copyright 2015 Ortus Solutions, Corp
+ * www.ortussolutions.com
+ **************************************************************************************
+ */
+component {
 
-	this.name = "DocBox Testing Suite";
+	this.name                 = "DocBox Testing Suite";
 	// any mappings go here, we create one that points to the root called test.
 	this.mappings[ "/tests" ] = getDirectoryFromPath( getCurrentTemplatePath() );
-	rootPath = REReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
-	this.mappings[ "/docbox" ] = rootPath;
+	rootPath                  = reReplaceNoCase(
+		this.mappings[ "/tests" ],
+		"tests(\\|/)",
+		""
+	);
+	this.mappings[ "/docbox" ]  = rootPath;
 	this.mappings[ "/coldbox" ] = getDirectoryFromPath( getCurrentTemplatePath() ) & "coldbox";
 
 }

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -41,16 +41,18 @@ component extends="testbox.system.BaseSpec" {
 			} );
 
 			it( "defaults to HTML if no strategy is set", function(){
-				variables.docbox.init(
-					properties = {
-						projectTitle = "Test", outputDir = variables.HTMLOutputDir
-					}
-				)
-				.generate(
-					source   = expandPath( "/tests" ),
-					mapping  = "tests",
-					excludes = "(coldbox|build\-docbox)"
-				);
+				variables.docbox
+					.init(
+						properties = {
+							projectTitle : "Test",
+							outputDir    : variables.HTMLOutputDir
+						}
+					)
+					.generate(
+						source   = expandPath( "/tests" ),
+						mapping  = "tests",
+						excludes = "(coldbox|build\-docbox)"
+					);
 				expect( variables.docbox.getStrategies() ).notTobeEmpty();
 			} );
 


### PR DESCRIPTION
If line breaks are present in the "hint", format them into paragraphs for a much cleaner description.

i.e. take this documentation:

```
/**
 * Wraps the Vehicles API to provide higher-order methods for pulling vehicle data.
 *
 * If you find yourself manipulating vehicle data frequently and consistently, consider moving that vehicle transformation logic into this component.
 */
component{}
```

from this:
![single-line component hint with no paragraph break](https://user-images.githubusercontent.com/8106227/115026875-00744b00-9e91-11eb-89ac-4c5a63fc3537.png)

to this:

![double-line component hint with paragraph break](https://user-images.githubusercontent.com/8106227/115026881-023e0e80-9e91-11eb-89ca-55f2a74e857d.png)
