### PR TITLE
docs: Fix broken DocBox example on Forgebox hosted Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ DocBox is a JavaDoc-style documentation generator for your CFML codebase based o
 
 [Docs][1] | [Github][2] | [Ortus Community][3]
 
-![Coldbox 5 Router class documentation, generated via DocBox](coldbox-5-router-documentation.png)
+![Coldbox 5 Router class documentation, generated via DocBox](https://github.com/Ortus-Solutions/DocBox/blob/development/coldbox-5-router-documentation.png)
 
 ## FEATURES
 


### PR DESCRIPTION
Point to the Github-hosted version of the png file so the Forgebox and other hosted readmes show the file properly.

See broken image on Forgebox:

![Screenshot from 2021-04-29 09-20-44](https://user-images.githubusercontent.com/8106227/116557196-33c0cc00-a8cc-11eb-930f-092860537213.png)