### PR TITLE
📘 Auto-build DocBox documentation for GitHub Pages

### DIFF
--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -1,0 +1,23 @@
+name: DocBox
+on:
+  push:
+    branches:
+      - master
+      - main
+    # Only run if *.cfc files are modified
+    paths:
+      - '**.cfc'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Ortus-Solutions/commandbox-action@v1
+        with:
+          cmd: docbox generate strategy=HTML mapping=DocBox excludes=test|ModuleConfig strategy-outputDir=docs strategy-projectTitle=DocBox
+      - name: Commit Docs Pages
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: gh-pages
+          commit_message: "📖 DOC: Auto-generate DocBox API docs"

--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: Ortus-Solutions/commandbox-action@v1
         with:
           cmd: docbox generate strategy=HTML mapping=DocBox excludes=test|ModuleConfig strategy-outputDir=docs strategy-projectTitle=DocBox
+
       - name: Commit Docs Pages
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: gh-pages
+          branch: master
           commit_message: "📖 DOC: Auto-generate DocBox API docs"

--- a/box.json
+++ b/box.json
@@ -34,6 +34,7 @@
         "**/.*",
         "tests/**",
         ".git*",
+        "docs/",
         "coldbox-5-router-documentation.png"
     ],
     "scripts":{

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -1,5 +1,5 @@
 /**
- * My BDD Test
+ * Test the main DocBox model
  */
 component extends="testbox.system.BaseSpec" {
 

--- a/tests/specs/HTMLAPIStrategyTest.cfc
+++ b/tests/specs/HTMLAPIStrategyTest.cfc
@@ -1,5 +1,5 @@
 /**
- * My BDD Test
+ * Test HTML documentation strategy
  */
 component extends="testbox.system.BaseSpec" {
 
@@ -35,7 +35,7 @@ component extends="testbox.system.BaseSpec" {
 				);
 			} );
 
-			it( "produces JSON output in the correct directory", function(){
+			it( "produces HTML output in the correct directory", function(){
 				variables.docbox.generate(
 					source   = expandPath( "/tests" ),
 					mapping  = "tests",


### PR DESCRIPTION
DocBox needs auto-documentation, and [we already have GitHub pages docs for DocBox](https://ortus-solutions.github.io/DocBox/docs/). Why not use DocBox to build documentation which can be automatically hosted on GitHub pages?

See example: https://michaelborn.github.io/DocBox/