### PR TITLE
"component has errors" message misses the point 😜

### DIFF
--- a/DocBox.cfc
+++ b/DocBox.cfc
@@ -257,11 +257,11 @@ component accessors="true" {
 						type     = "warning",
 						category = "docbox",
 						inline   = "true",
-						text     = "Warning! The following script has errors: " & packagePath & cfcName & ": #e.message & e.detail & e.stacktrace#"
+						text     = "Warning! The following script has errors: " & packagePath & "." & cfcName & ": #e.message & e.detail & e.stacktrace#"
 					);
 					if ( structKeyExists( server, "lucee" ) ) {
 						systemOutput(
-							"Warning! The following script has errors: " & packagePath & cfcName,
+							"Warning! The following script has errors: " & packagePath & "." & cfcName,
 							true
 						);
 						systemOutput( "#e.message & e.detail#", true );


### PR DESCRIPTION
For example, this error:

> Warning! The following script has errors: demoApp.coldbox.systemInterceptor

This should be:

> Warning! The following script has errors: demoApp.coldbox.system.Interceptor

Clearly, we're missing the point. 😜