### PR TITLE
Add `throwOnError` - allow failing the docs build if DocBox finds an invalid component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tests/tmp/
 .artifacts/*
 .tmp/*
 changelog-latest.md
+tests/FunkyComponent.cfc

--- a/tests/specs/DocBoxTest.cfc
+++ b/tests/specs/DocBoxTest.cfc
@@ -19,6 +19,10 @@ component extends="testbox.system.BaseSpec" {
 				resetTmpDirectory( variables.HTMLOutputDir );
 				resetTmpDirectory( variables.JSONOutputDir );
 
+				if ( fileExists( expandPath( "/tests/FunkyComponent.cfc" ) ) ){
+					fileDelete( expandPath( "/tests/FunkyComponent.cfc" ) );
+				}
+
 				variables.docbox = new docbox.DocBox();
 			} );
 
@@ -147,6 +151,52 @@ component extends="testbox.system.BaseSpec" {
 					"should generate overview-summary.json class index file"
 				);
 			} );
+
+			/**
+			 * Skipped until we implement a throwOnError=true.
+			 * Until we can catch the thrown errors, there's nothing much to test here.
+			 */
+			it( "throws on invalid component if throwOnError=true", function() {
+				var componentCode = "componentxyz{}";
+				if ( !fileExists( expandPath( "/tests/FunkyComponent.cfc" ) ) ){
+					fileWrite( expandPath( "/tests/FunkyComponent.cfc" ), componentCode );
+				}
+				expect( function(){
+					variables.docbox.init(
+						properties = {
+							projectTitle = "Test",
+							outputDir = variables.HTMLOutputDir
+						}
+					)
+					.generate(
+						source       = expandPath( "/tests" ),
+						mapping      = "tests",
+						excludes     = "(coldbox|build\-docbox)",
+						throwOnError = true
+					);
+				}).toThrow( "InvalidComponentException" );
+			});
+
+			it( "does not throw on invalid component if throwOnError=false", function() {
+				var componentCode = "componentxyz{}";
+				if ( !fileExists( expandPath( "/tests/FunkyComponent.cfc" ) ) ){
+					fileWrite( expandPath( "/tests/FunkyComponent.cfc" ), componentCode );
+				}
+				expect( function(){
+					variables.docbox.init(
+						properties = {
+							projectTitle = "Test",
+							outputDir = variables.HTMLOutputDir
+						}
+					)
+					.generate(
+						source       = expandPath( "/tests" ),
+						mapping      = "tests",
+						excludes     = "(coldbox|build\-docbox)",
+						throwOnError = false
+					);
+				}).notToThrow( "InvalidComponentException" );
+			});
 		} );
 	}
 


### PR DESCRIPTION
📦 NEW: Add `throwOnError` boolean argument to `generate()` method
    
Allow docbox builds to fail if an invalid component is encountered during component metadata parsing.

Defaults to `false`.